### PR TITLE
Fix wrong format specifier in assertion_fail

### DIFF
--- a/src/util/check.cpp
+++ b/src/util/check.cpp
@@ -29,7 +29,7 @@ NonFatalCheckError::NonFatalCheckError(std::string_view msg, std::string_view fi
 
 void assertion_fail(std::string_view file, int line, std::string_view func, std::string_view assertion)
 {
-    auto str = strprintf("%s:%s %s: Assertion `%s' failed.\n", file, line, func, assertion);
+    auto str = strprintf("%s:%d %s: Assertion `%s' failed.\n", file, line, func, assertion);
     fwrite(str.data(), 1, str.size(), stderr);
     std::abort();
 }


### PR DESCRIPTION
## Summary
- fix wrong type in assertion_fail format string

## Testing
- `python3 test/lint/lint-python-dead-code.py`

------
https://chatgpt.com/codex/tasks/task_e_6887e2b6a3548321be56262c70d504bd